### PR TITLE
Use Gio._promisify for NM.Client.new_async

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,12 @@
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 import NM from 'gi://NM';
 import * as Rfkill from 'resource:///org/gnome/shell/ui/status/rfkill.js';
 import {Extension, gettext as _} from 'resource:////org/gnome/shell/extensions/extension.js';
 
 import * as Constants from './constants.js';
+
+Gio._promisify(NM.Client, 'new_async');
 
 let ENABLE_WIFI            = false;
 let ENABLE_BLUETOOTH       = true;


### PR DESCRIPTION
In #11 it was noted that

```javascript
this._client = await NM.Client.new_async(null);
```

is used by GNOME dev by themself (see [here](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/status/network.js#L1998)). But compared to our sources we are missing `Gio._promisify` call which makes the syntax work.